### PR TITLE
issue 1 corrected per request and tested - 2402 on win11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "citrix-autolaunch"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,9 +94,11 @@ fn main() {
             State::ReadyToLaunch => {
                 // Launch ICA file in default application
                 spit("Launching file...");
-                match launch_file(file_name.as_str()) {
+                let target = file_name.clone();
+                file_name = String::new();
+                match launch_file(target.as_str()) {
                     Ok(_) => {
-                        let msg = format!("File launched successfully: {}", file_name);
+                        let msg = format!("File launched successfully: {}", target);
                         spit(msg);
                         sleep(std::time::Duration::from_secs(5));
                     }


### PR DESCRIPTION
Setting file_name to blank on launch is confirmed to prevent the error occurring